### PR TITLE
Fix small styling bug

### DIFF
--- a/src/components/utilities/Frame/Frame.vue
+++ b/src/components/utilities/Frame/Frame.vue
@@ -20,7 +20,7 @@ export default {
 @import '../../../styles/core/layout.css';
 
 .frame-default {
-  @apply .container pb-6 pt-6;
+  @apply container pb-6 pt-6;
 }
 
 .frame-indent {


### PR DESCRIPTION
Fixes a small bug when using Tailwind with PostCSS:

```
Syntax Error: SyntaxError

Frame.vue The `.container` class does not exist, but `container` does. If you're sure that `.container` exists, make sure that any `@import` statements are being properly processed before Tailwind CSS sees your CSS, as `@apply` can only be used for classes in the same CSS tree.
```